### PR TITLE
Add support for building composite buildpacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOCMD?=go
 GO_VERSION=$(shell go list -m -f "{{.GoVersion}}")
 LIBPAKTOOLS_VERSION=$(shell ./scripts/version.sh)
 PACKAGE_BASE=github.com/paketo-buildpacks/libpak-tools
-OUTDIR=./binaries
+OUTDIR=$(HOME)/go/bin
 LDFLAGS="-s -w"
 
 all: test libpak-tools
@@ -14,13 +14,6 @@ out:
 libpak-tools: out
 	@echo "> Building libpak-tools..."
 	go build -ldflags=$(LDFLAGS) -o $(OUTDIR)/libpak-tools main.go
-
-package: OUTDIR=./bin
-package: clean libpak-tools
-	@echo "> Packaging up binaries..."
-	mkdir -p dist/
-	tar czf dist/libpak-tools-$(LIBPAKTOOLS_VERSION).tgz $(OUTDIR)/*
-	rm -rf ./bin
 
 install-goimports:
 	@echo "> Installing goimports..."

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This repository pulls together and publishes a number of helpful tools for the management and release of buildpacks.
 
+## Configuration Environment Variables
+
+| Name                  | Default                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| --------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `BP_ROOT`             | ``                                         | The location where you have `git clone`'d all of the buildpacks. The structure should be `$BP_ROOT/<github_org>/<github_repo>`. For example: `$BP_ROOT/paketo-buildpacks/bellsoft-liberica`. This setting is required *if* you want the tool to infer where your buildpacks live based on the `--buildpack-id` you supply. If you do not include it, then you need to include the `--buildpack-path` argument to indicate the specific location of the buildpack to use. |
+| `BP_ARCH`             | `runtime.GOARCH` (i.e. your system's arch) | This does not generally need to be set, but you can use it to override the automatically detected architecture. This might be helpful if you're on M-series Mac hardware and can build for multiple architectures.                                                                                                                                                                                                                                                       |
+| `BP_PULL_POLICY`      | `if-not-present`                           | This will allow you to override the pull policy. The tool specifically sets pull policy, and does not default to pack's default.                                                                                                                                                                                                                                                                                                                                         |
+| `BP_FLATTEN_DISABLED` | `false`                                    | This will disable flattening of composite buildpacks. By default, the tool will flatten composite buildpacks which takes all of the component buildpacks in that composite buildpack and puts them into one layer, instead of many layers.                                                                                                                                                                                                                               |
+
 ## `libpak-tools package compile`
 
 The `package compile` command creates a `libpak.Package` and calls `libpak.Package.Create()`. This takes a Paketo buildpack written in Go and packages is it into a buildpack. That involves compiling the source code, possibly copying in additional resource files, and generating the buildpack in the given output directory. The key is that the output of this command is a *directory*. If you want it to output an image, use `libpak-tools package bundle`.
@@ -29,8 +38,7 @@ Flags:
 The `package bundle` does the same thing as `libpak-tools package compile` but then runs `pack buildpack package` as well, so the output is a buildpack image.
 
 ```
-> libpak-tools package bundle -h
-Compile and package a single buildpack
+Compile and package a single buildpack (component & composite)
 
 Usage:
   libpak-tools package bundle [flags]
@@ -42,6 +50,8 @@ Flags:
       --dependency-filter stringArray   one or more filters that are applied to exclude dependencies
   -h, --help                            help for bundle
       --include-dependencies            whether to include dependencies (default: false)
+      --publish                         publish the buildpack to a buildpack registry (default: false)
+      --registry-name string            prefix for the registry to publish to (default: your buildpack id)
       --strict-filters                  require filter to match all data or just some data (default: false)
       --version string                  version to substitute into buildpack.toml/extension.toml
 ```

--- a/commands/package_buildpack.go
+++ b/commands/package_buildpack.go
@@ -29,7 +29,7 @@ func PackageBundleCommand() *cobra.Command {
 
 	var packageBuildpackCmd = &cobra.Command{
 		Use:   "bundle",
-		Short: "Compile and package a single buildpack",
+		Short: "Compile and package a single buildpack (component & composite)",
 		Run: func(cmd *cobra.Command, args []string) {
 			if p.BuildpackID == "" && p.BuildpackPath == "" {
 				log.Fatal("buildpack-id or buildpack-path must be set")
@@ -40,11 +40,15 @@ func PackageBundleCommand() *cobra.Command {
 			}
 
 			if p.BuildpackID != "" && p.BuildpackPath == "" {
-				p.InferBuildpackPath()
+				if err := p.InferBuildpackPath(); err != nil {
+					log.Fatal(err)
+				}
 			}
 
 			if p.BuildpackVersion == "" {
-				p.InferBuildpackVersion()
+				if err := p.InferBuildpackVersion(); err != nil {
+					log.Fatal(err)
+				}
 			}
 
 			if p.RegistryName == "" {


### PR DESCRIPTION
## Summary

This PR resolves #48. It adds the ability for `libpak-tools package bundle` to build composite buildpacks. It does nothing fancy and is just a wrapper around the similar pack command, but it does help to enforce some default settings so it should be as easy as `libpak-tools package bundle --buildpack-id paketo-buildpacks/java` to build the composite.

You can then manually adjust `package.toml` and point to local images, rebuild and get a composite image with custom buildpack changes.

In addition, it fixes a bug where a missing `BP_ROOT` was ignored, which was confusing. It also does a little refactoring renaming some variables to better indicate intent.

## Use Cases

Build composite buildpacks.
