### PR TITLE
Add output path & skip clean options

### DIFF
--- a/builder/jvm_vendors.go
+++ b/builder/jvm_vendors.go
@@ -54,6 +54,7 @@ type BuildJvmVendorsCommand struct {
 	RegistryName            string
 	Publish                 bool
 	Format                  string
+	OutputPath              string
 	JVMVendors              []JVMVendor
 }
 
@@ -166,6 +167,8 @@ func (b *BuildJvmVendorsCommand) BuildSingleBuildpack() error {
 	pkgCmd.Publish = b.Publish
 	pkgCmd.Format = b.Format
 	pkgCmd.OutputName = "jvm-vendors.cnb"
+	pkgCmd.OutputPath = b.OutputPath
+	pkgCmd.SkipClean = b.Format == "file"
 	return pkgCmd.Execute()
 }
 
@@ -203,7 +206,8 @@ func (b *BuildJvmVendorsCommand) BuildMultipleBuildpacks() error {
 		pkgCmd.Publish = b.Publish
 		pkgCmd.Format = b.Format
 		pkgCmd.OutputName = fmt.Sprintf("%s.cnb", selectedVendor.VendorID)
-		pkgCmd.SkipClean = i < len(b.BuildpackIDs)-1 // Skip clean on the last buildpack to avoid cleaning up resources needed for subsequent builds
+		pkgCmd.OutputPath = b.OutputPath
+		pkgCmd.SkipClean = b.Format == "file" || i < len(b.BuildpackIDs)-1
 		if err := pkgCmd.Execute(); err != nil {
 			return err
 		}

--- a/commands/build_jvm.go
+++ b/commands/build_jvm.go
@@ -70,6 +70,7 @@ func BuildJvmVendorsCommand() *cobra.Command {
 	buildJvmVendorsCommand.Flags().StringVar(&i.RegistryName, "registry-name", "", "prefix for the registry to publish to, applies to all buildpacks (default: the buildpack id)")
 	buildJvmVendorsCommand.Flags().BoolVar(&i.Publish, "publish", false, "publish the buildpack to a buildpack registry, applies to all buildpacks (default: false)")
 	buildJvmVendorsCommand.Flags().StringVar(&i.Format, "format", "image", "format for the output, either image or file (default: image)")
+	buildJvmVendorsCommand.Flags().StringVar(&i.OutputPath, "output-path", "", "path to directory where output files will be created (default: current directory)")
 
 	return buildJvmVendorsCommand
 }

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -22,7 +22,10 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/libpak/v2/effect"
+	"github.com/paketo-buildpacks/libpak/v2/effect/mocks"
 	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/paketo-buildpacks/libpak-tools/builder"
 	"github.com/paketo-buildpacks/libpak-tools/carton"
@@ -278,10 +281,23 @@ homepage = "https://example.com"
 `), 0600)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(buildpackPath, "package.toml"), []byte("[metadata]\n"), 0600)).To(Succeed())
 
-			p := packager.NewBundleBuildpack()
+			mockExecutor := &mocks.Executor{}
+			mockExecutor.On("Execute", mock.MatchedBy(func(e effect.Execution) bool {
+				return e.Command == "pack" && e.Args[0] == "buildpack" && e.Args[1] == "package"
+			})).Return(nil).Once()
+			mockExecutor.On("Execute", mock.MatchedBy(func(e effect.Execution) bool {
+				return e.Command == "docker" && e.Args[0] == "image" && e.Args[1] == "ls"
+			})).Return(func(ex effect.Execution) error {
+				_, err := ex.Stdout.Write([]byte("  "))
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			}).Once()
+
+			p := packager.NewBundleBuildpackForTests(mockExecutor, nil)
 			p.BuildpackID = "some-id"
 			p.BuildpackPath = buildpackPath
 			p.BuildpackVersion = "1.0.0"
+			p.Format = "image"
 
 			Expect(runPackageBundleCommand(&p)).To(Succeed())
 			Expect(p.RegistryName).To(Equal("some-id"))

--- a/packager/buildpack.go
+++ b/packager/buildpack.go
@@ -64,6 +64,9 @@ type BundleBuildpack struct {
 	// OutputName is the name of the output file when format is set to file, defaults to buildpackage.cnb in the buildpack directory
 	OutputName string
 
+	// OutputPath is the directory where output files will be created
+	OutputPath string
+
 	// Publish indicates whether to publish the buildpack to the registry
 	Publish bool
 
@@ -200,12 +203,25 @@ func (p *BundleBuildpack) ExecutePackage(workingDirectory string, additionalArgs
 	}
 
 	if p.Format == "file" {
-		absBuildpackPath, err := filepath.Abs(p.BuildpackPath)
-		if err != nil {
-			return fmt.Errorf("unable to resolve absolute buildpack path: %w", err)
+		if p.OutputPath == "" {
+			absBuildpackPath, err := filepath.Abs(p.BuildpackPath)
+			if err != nil {
+				return fmt.Errorf("unable to resolve absolute buildpack path: %w", err)
+			}
+			p.OutputPath = absBuildpackPath
+		} else {
+			absOutputPath, err := filepath.Abs(p.OutputPath)
+			if err != nil {
+				return fmt.Errorf("unable to resolve absolute output path: %w", err)
+			}
+			p.OutputPath = absOutputPath
 		}
 
-		outputName = filepath.Join(absBuildpackPath, p.OutputName)
+		if err := os.MkdirAll(p.OutputPath, 0755); err != nil {
+			return fmt.Errorf("unable to make directory at path [%s]: %w", p.OutputPath, err)
+		}
+
+		outputName = filepath.Join(p.OutputPath, p.OutputName)
 	}
 
 	args := []string{
@@ -280,8 +296,17 @@ func (p *BundleBuildpack) GZipBuildpack(destDir string) error {
 		return fmt.Errorf("unable to close archive file\n%w", err)
 	}
 
-	// move the archive to the buildpack directory, so it survives the temp build directory
-	destArchivePath := filepath.Join(p.BuildpackPath, strings.Replace(p.OutputName, ".cnb", ".tgz", 1))
+	outputDir := p.OutputPath
+	if outputDir == "" {
+		outputDir = p.BuildpackPath
+	}
+
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("unable to create output directory\n%w", err)
+	}
+
+	// move the archive to the output directory, so it survives the temp build directory
+	destArchivePath := filepath.Join(outputDir, strings.Replace(p.OutputName, ".cnb", ".tgz", 1))
 	if err := sherpa.CopyFileFrom(archivePath, destArchivePath); err != nil {
 		return fmt.Errorf("unable to copy archive to buildpack directory\n%w", err)
 	}

--- a/packager/buildpack_test.go
+++ b/packager/buildpack_test.go
@@ -360,11 +360,14 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("uses default output name with buildpack path prefix for file format", func() {
+			tempDir := t.TempDir()
+			outputDir := filepath.Join(tempDir, "output")
+
 			mockExecutor.On("Execute", mock.MatchedBy(func(e effect.Execution) bool {
 				return e.Command == "pack" &&
 					e.Args[0] == "buildpack" &&
 					e.Args[1] == "package" &&
-					e.Args[2] == "/other/path/buildpackage.cnb" &&
+					e.Args[2] == filepath.Join(outputDir, "buildpackage.cnb") &&
 					e.Args[3] == "--pull-policy" &&
 					e.Args[4] == "if-not-present" &&
 					e.Args[5] == "--format" &&
@@ -377,18 +380,21 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			p := packager.NewBundleBuildpackForTests(mockExecutor, nil)
 			p.BuildpackID = "some-id"
 			p.Format = "file"
-			p.BuildpackPath = "/other/path"
+			p.BuildpackPath = outputDir
 			p.OutputName = "buildpackage.cnb"
 
 			Expect(p.ExecutePackage("/some/path")).To(Succeed())
 		})
 
 		it("uses custom output name with buildpack path prefix for file format", func() {
+			tempDir := t.TempDir()
+			outputDir := filepath.Join(tempDir, "output")
+
 			mockExecutor.On("Execute", mock.MatchedBy(func(e effect.Execution) bool {
 				return e.Command == "pack" &&
 					e.Args[0] == "buildpack" &&
 					e.Args[1] == "package" &&
-					e.Args[2] == "/other/path/custom-output.cnb" &&
+					e.Args[2] == filepath.Join(outputDir, "custom-output.cnb") &&
 					e.Args[3] == "--pull-policy" &&
 					e.Args[4] == "if-not-present" &&
 					e.Args[5] == "--format" &&
@@ -401,7 +407,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			p := packager.NewBundleBuildpackForTests(mockExecutor, nil)
 			p.BuildpackID = "some-id"
 			p.Format = "file"
-			p.BuildpackPath = "/other/path"
+			p.BuildpackPath = outputDir
 			p.OutputName = "custom-output.cnb"
 
 			Expect(p.ExecutePackage("/some/path")).To(Succeed())
@@ -627,6 +633,37 @@ homepage = "https://example.com"
 			p := packager.NewBundleBuildpackForTests(mockExecutor, nil)
 			p.BuildpackID = "some-id"
 			p.BuildpackPath = buildpackPath
+
+			Expect(p.Execute()).To(Succeed())
+		})
+
+		it("bundles composite buildpacks and skips cleaning docker images when SkipClean is true", func() {
+			buildpackPath := t.TempDir()
+			mockExecutor := &mocks.Executor{}
+
+			Expect(os.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"), []byte(`[buildpack]
+id = "some-id"
+version = "1.0.0"
+name = "Some Buildpack"
+description = "A buildpack for testing"
+homepage = "https://example.com"
+`), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(buildpackPath, "package.toml"), []byte("[metadata]\n"), 0600)).To(Succeed())
+
+			mockExecutor.On("Execute", mock.MatchedBy(func(e effect.Execution) bool {
+				if e.Command != "pack" || e.Args[0] != "buildpack" || e.Args[1] != "package" {
+					return false
+				}
+				Expect(e.Args).To(ContainElement("--config"))
+				Expect(e.Args).To(ContainElement("--flatten"))
+				Expect(e.Dir).To(Equal(buildpackPath))
+				return true
+			})).Return(nil).Once()
+
+			p := packager.NewBundleBuildpackForTests(mockExecutor, nil)
+			p.BuildpackID = "some-id"
+			p.BuildpackPath = buildpackPath
+			p.SkipClean = true
 
 			Expect(p.Execute()).To(Succeed())
 		})


### PR DESCRIPTION
## Summary

1. Output path will put all of the generate image files into the given output path. This only works with `--format=file`.
2. Skip clean option will skip trying to delete docker images & clean up docker resources. This defaults to false, so it will clean up when run locally. This is the existing behavior. When you set `--format=file` it will default to true, since it is not pushing anything into Docker.
